### PR TITLE
Fix API JSON error writer

### DIFF
--- a/cmd/api/health.go
+++ b/cmd/api/health.go
@@ -21,14 +21,10 @@ func (app *application) healthCheckHandler(w http.ResponseWriter, r *http.Reques
 }
 
 func (app *application) writeJSONError(w http.ResponseWriter, status int, err error) {
-	w.Header().Set("Content-Type", "application/json")
-	w.Header().Set("Cache-Control", "no-cache")
-	w.WriteHeader(status)
 	data := map[string]string{
 		"error": err.Error(),
 	}
 	if err := writeJSON(w, status, data); err != nil {
-		log.Fatal("Failed to write JSON error response:", err)
-		// Handle the error as needed, e.g., log it or return an error response
+		log.Println("Failed to write JSON error response:", err)
 	}
 }


### PR DESCRIPTION
## Summary
- fix duplicated header writes in `writeJSONError`

## Testing
- `go test ./cmd/shapes`
- `go vet ./...` *(fails: module download blocked)*

------
https://chatgpt.com/codex/tasks/task_e_684be39fc3ac8323b195548a721b6e3d